### PR TITLE
Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Permitted Feign Client Library [![Build Status](https://api.travis-ci.com/apache/fineract-cn-permitted-feign-client.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-permitted-feign-client)
+# Apache Fineract CN Permitted Feign Client Library
 
 This project provides secured access to other services via Feign. For this it uses anubis and identity to provide refresh and access tokens transparently.
 


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.